### PR TITLE
When cdn registry fetch fails, do not update tarball urls

### DIFF
--- a/src/poll.js
+++ b/src/poll.js
@@ -107,7 +107,7 @@ function pollInstallDistTag({ name, onError, tag, period = 20, dependencies = fa
     const stability : { [string] : string } = {};
 
     const pollInstall = async () : Promise<ModuleDetails> => {
-        const moduleInfo = await info(name, { logger, cache, registry, cdnRegistry });
+        const { moduleInfo } = await info(name, { logger, cache, registry, cdnRegistry });
 
         let distTagVersion = moduleInfo[DIST_TAGS][tag];
 


### PR DESCRIPTION
This PR fixes the failing unit tests related to falling back to the npm registry when the cdn registry is unavailable. 