### PR TITLE
add logging to cleanup task

### DIFF
--- a/src/poll.js
+++ b/src/poll.js
@@ -187,7 +187,8 @@ function pollInstallDistTag({ name, onError, tag, period = 20, dependencies = fa
             dir:       liveModulesDir,
             interval:  CLEAN_INTERVAL,
             threshold: CLEAN_THRESHOLD,
-            onError
+            onError,
+            logger
         });
 
         cleanTask.save(prefix);


### PR DESCRIPTION
There will be another PR to https://github.com/krakenjs/grabthar-release/ to change the way cdnify works. We want it to stop pruning old versions. In its current state, we lose the `previousVersion` function of grabthar which puts `clientsdknodeweb` under a lot of stress during an sdk deploy.

We want to add some additional logging to `grabthar` to make sure that it is cleaning up unused versions from the servers' filesystem. We want to make sure that when we introduce this change, we can make sure that we are properly cleaning up after ourselves.