### PR TITLE
feat: expose import and read

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
 /* @flow */
 
-export { npmPoll as poll, getFallback as getVersionFromNodeModules, importDependency } from './poll';
+export { npmPoll as poll, getFallback as getVersionFromNodeModules, importDependency, importParent, getFile } from './poll';
 export { installVersion } from './npm';


### PR DESCRIPTION
exposes `import` as `importParent`. import is a reserved word so we can't just export import.

exposes `read` as `getFile`. I thought that `read` doesn't really convey what's actually happening here, its returning a file at a path.